### PR TITLE
Publish images when page publishes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+Copyright © 2020 Wunderman Thompson New Zealand
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies
+or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SilverStripe Facebook Image
 
-This version supports SilverStripe 3, see the 0.0 branch for a SilverStripe 2.4 compatible version.
+This version supports SilverStripe 4, see the 0.1 release for a SilverStripe 3 compatible version and the 0.0 release for a SilverStripe 2.4 compatible version.
 
 Provides an Image Field for use when sharing pages on facebook.
 

--- a/code/PageFacebookImageExtension.php
+++ b/code/PageFacebookImageExtension.php
@@ -11,10 +11,23 @@ use SilverStripe\SiteConfig\SiteConfig;
 
 class PageFacebookImageExtension extends DataExtension
 {
-    private static $has_one = array(
+    /**
+     * @var array
+     */
+    private static $has_one = [
         'FacebookImage' => Image::class,
-    );
+    ];
 
+    /**
+     * @var array
+     */
+    private static $owns = [
+        'FacebookImage',
+    ];
+
+    /**
+     * @param FieldList $fields
+     */
     public function updateCMSFields(FieldList $fields)
     {
         $fields->addFieldToTab(

--- a/code/SiteConfigFacebookImageExtension.php
+++ b/code/SiteConfigFacebookImageExtension.php
@@ -9,10 +9,23 @@ use SilverStripe\ORM\DataExtension;
 
 class SiteConfigFacebookImageExtension extends DataExtension
 {
-    private static $has_one = array(
+    /**
+     * @var array
+     */
+    private static $has_one = [
         'FacebookImage' => Image::class,
-    );
+    ];
 
+    /**
+     * @var array
+     */
+    private static $owns = [
+        'FacebookImage',
+    ];
+
+    /**
+     * @param FieldList $fields
+     */
     public function updateCMSFields(FieldList $fields)
     {
         $fields->addFieldToTab(

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
 		}
 	],
 	"require": {
-		"composer/installers": "~1.0"
+		"composer/installers": "~1.0",
+		"silverstripe/framework": "^4.0.0"
 	}
 }


### PR DESCRIPTION
updated composer to require SilverStripe 4, updated readme, added license, updated extensions to use ownership of images.
This means that images publish when the page they're used on publishes, and also that the "used on" tab (in the admin panel for the image) will show what pages/dataobjects it's used on.